### PR TITLE
Change argument types to compatibility with doctrine dbal

### DIFF
--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -25,7 +25,7 @@ final class Hydrator
      * @template T of object
      *
      * @param class-string<T> $class
-     * @param array<non-empty-string, mixed> $data
+     * @param array<string, mixed> $data
      *
      * @return T
      */

--- a/src/Instantinator.php
+++ b/src/Instantinator.php
@@ -13,7 +13,7 @@ interface Instantinator
      * @template T of object
      *
      * @param class-string<T> $class
-     * @param array<non-empty-string, mixed> $data
+     * @param array<string, mixed> $data
      *
      * @return T
      *

--- a/src/ObjectHydrator.php
+++ b/src/ObjectHydrator.php
@@ -37,9 +37,9 @@ final class ObjectHydrator
      * @template T of object
      *
      * @param class-string<T> $class
-     * @param array<non-empty-string, mixed> $data
-     * @param array<non-empty-string, non-empty-string|EnumType> $types Map keys of $class property to doctrine type
-     * @param array<non-empty-string, non-empty-string> $mapping Map keys of $data to properties of $class
+     * @param array<string, mixed> $data
+     * @param array<string, non-empty-string|EnumType> $types Map keys of $class property to doctrine type
+     * @param array<string, string> $mapping Map keys of $data to properties of $class
      *
      * @return T
      *

--- a/src/SimpleInstantinator.php
+++ b/src/SimpleInstantinator.php
@@ -34,7 +34,7 @@ final class SimpleInstantinator implements Instantinator
      * @template T of object
      *
      * @param \ReflectionClass<T> $refClass
-     * @param array<non-empty-string, mixed> $data
+     * @param array<string, mixed> $data
      *
      * @return T
      *


### PR DESCRIPTION
**Before:**

Argument `$data` of `Hydrator::hydrate()` expects `array<non-empty-string, mixed>`. But Doctrine DBAL result associative array methods will return `array<string, mixed>`.

You need redefine return type of doctrine result for static analize tools.

Example:

```php
/** @var array<non-empty-string, mixed> */ // Redefine  type of $data
$data = $this->connection->executeQuery('SELECT 1')->fetchAssociative(); // Real return array<string, mixed>
$this->hydrator->hydrate(Dto::class, $data);
```

**After:**

Doctrine DBAL result type and expected `$data` argument type is compatibility.